### PR TITLE
Change ArcGIS CSP endpoints to use wildcards

### DIFF
--- a/src/infra/components/reefGuideFrontend.ts
+++ b/src/infra/components/reefGuideFrontend.ts
@@ -19,8 +19,8 @@ export interface ReefGuideFrontendProps {
   usEastCertificate: acm.ICertificate;
   /** The configuration object for the ReefGuideFrontend service */
   config: ReefGuideFrontendConfig;
-  /** CSP endpoints */
-  cspEndpoints: string[];
+  /** CSP entries and endpoints */
+  cspEntries: string[];
 }
 
 /**
@@ -61,8 +61,7 @@ export class ReefGuideFrontend extends Construct {
       securityHeadersBehavior: {
         contentSecurityPolicy: {
           // enable connection to the various API services needed
-          // App may generate blob object URLs
-          contentSecurityPolicy: `connect-src 'self' blob: ${props.cspEndpoints.join(
+          contentSecurityPolicy: `connect-src 'self' ${props.cspEntries.join(
             ' ',
           )}`,
           override: true,

--- a/src/infra/infra.ts
+++ b/src/infra/infra.ts
@@ -104,7 +104,8 @@ export class ReefguideWebApiStack extends cdk.Stack {
       domainName: domains.frontend,
       hz: hz,
       // This overrides CSP to allow the browser to use these endpoints
-      cspEndpoints: [reefGuideApi.endpoint, webAPI.endpoint].concat(
+      // App may generate blob object URLs.
+      cspEntries: [reefGuideApi.endpoint, webAPI.endpoint, 'blob:'].concat(
         ARC_GIS_ENDPOINTS,
       ),
     });


### PR DESCRIPTION
Layer I'm using has a CSP error.
> chunk-AFLVK3UD.js:1 Refused to connect to 'https://services3.arcgis.com/wfyOCawpdks4prqC/arcgis/rest/services/Reef_Notes/FeatureServer?f=json' because it violates the following Content Security Policy directive: "connect-src 'self' https://guide-api.reefguide.mds.gbrrestoration.org:443 https://web-api.reefguide.mds.gbrrestoration.org https://js.arcgis.com https://www.arcgis.com https://static.arcgis.com https://basemaps.arcgis.com https://cdn.arcgis.com https://server.arcgisonline.com https://services.arcgisonline.com https://tiles.arcgis.com".

change to wildcards
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#hosts_values

Add `blob:` for now. I'm using it for the alternate COG implementation. Will decide if we should avoid it in the future.
