### PR TITLE
Improvements to type descriptions and errors

### DIFF
--- a/src/api/services/jobs.ts
+++ b/src/api/services/jobs.ts
@@ -40,8 +40,10 @@ const sharedCriteriaSchema = z.object({
   reef_type: z.string().describe('The type of reef, slopes or flats'),
 
   // Criteria - all optional to match the Union{Float64,Nothing} in worker
-  depth_min: z.number().optional().describe('The depth range (min)'),
-  depth_max: z.number().optional().describe('The depth range (max)'),
+  depth_min: z.number().optional()
+    .describe('The depth minimum (the deeper more negative value)'),
+  depth_max: z.number().optional()
+    .describe('The depth maximum (the shallower less negative value)'),
   slope_min: z.number().optional().describe('The slope range (min)'),
   slope_max: z.number().optional().describe('The slope range (max)'),
   rugosity_min: z.number().optional().describe('The rugosity range (min)'),

--- a/src/api/services/jobs.ts
+++ b/src/api/services/jobs.ts
@@ -169,7 +169,8 @@ export class JobService {
     try {
       return schema.parse(payload);
     } catch (e) {
-      throw new BadRequestException(`Invalid payload for job type ${jobType}`);
+      const cause = e instanceof Error ? e : undefined;
+      throw new BadRequestException(`Invalid payload for job type ${jobType}`, cause);
     }
   }
 

--- a/src/api/services/jobs.ts
+++ b/src/api/services/jobs.ts
@@ -40,9 +40,13 @@ const sharedCriteriaSchema = z.object({
   reef_type: z.string().describe('The type of reef, slopes or flats'),
 
   // Criteria - all optional to match the Union{Float64,Nothing} in worker
-  depth_min: z.number().optional()
+  depth_min: z
+    .number()
+    .optional()
     .describe('The depth minimum (the deeper more negative value)'),
-  depth_max: z.number().optional()
+  depth_max: z
+    .number()
+    .optional()
     .describe('The depth maximum (the shallower less negative value)'),
   slope_min: z.number().optional().describe('The slope range (min)'),
   slope_max: z.number().optional().describe('The slope range (max)'),
@@ -170,7 +174,10 @@ export class JobService {
       return schema.parse(payload);
     } catch (e) {
       const cause = e instanceof Error ? e : undefined;
-      throw new BadRequestException(`Invalid payload for job type ${jobType}`, cause);
+      throw new BadRequestException(
+        `Invalid payload for job type ${jobType}`,
+        cause,
+      );
     }
   }
 


### PR DESCRIPTION
Clarify depth property is negative and the min/max.

Improve ZOD errors by setting cause.

## TODO

- [ ] are there other places where errors should have cause added?
- [ ] should cause only be added in dev mode?

### Example improved error

```
Error details:

Error: BadRequestException
Message: Invalid payload for job type REGIONAL_ASSESSMENT
Stack: BadRequestException: Invalid payload for job type REGIONAL_ASSESSMENT
    at JobService.validateJobPayload (C:\Users\awhite\code\reefguide-web-api\src\api\services\jobs.ts:176:13)
    at JobService.createJobRequest (C:\Users\awhite\code\reefguide-web-api\src\api\services\jobs.ts:286:16)
    at C:\Users\awhite\code\reefguide-web-api\src\api\jobs\routes.ts:133:58
    at newFn (C:\Users\awhite\code\reefguide-web-api\node_modules\express-async-errors\index.js:16:20)
    at Layer.handle [as handle_request] (C:\Users\awhite\code\reefguide-web-api\node_modules\express\lib\router\layer.js:95:5)
    at next (C:\Users\awhite\code\reefguide-web-api\node_modules\express\lib\router\route.js:149:13)
    at complete (C:\Users\awhite\code\reefguide-web-api\node_modules\passport\lib\middleware\authenticate.js:280:13)
    at C:\Users\awhite\code\reefguide-web-api\node_modules\passport\lib\middleware\authenticate.js:287:15
    at pass (C:\Users\awhite\code\reefguide-web-api\node_modules\passport\lib\authenticator.js:446:14)
    at Authenticator.transformAuthInfo (C:\Users\awhite\code\reefguide-web-api\node_modules\passport\lib\authenticator.js:468:5)

Caused by:

Error: ZodError
Message: [
  {
    "code": "unrecognized_keys",
    "keys": [
      "turbidity_min",
      "turbidity_max"
    ],
    "path": [],
    "message": "Unrecognized key(s) in object: 'turbidity_min', 'turbidity_max'"
  }
]
Stack: ZodError: [
  {
    "code": "unrecognized_keys",
    "keys": [
      "turbidity_min",
      "turbidity_max"
    ],
    "path": [],
    "message": "Unrecognized key(s) in object: 'turbidity_min', 'turbidity_max'"
  }
]
    at Object.get error [as error] (C:\Users\awhite\code\reefguide-web-api\node_modules\zod\lib\types.js:55:31)
    at ZodObject.parse (C:\Users\awhite\code\reefguide-web-api\node_modules\zod\lib\types.js:160:22)
    at JobService.validateJobPayload (C:\Users\awhite\code\reefguide-web-api\src\api\services\jobs.ts:172:21)
    at JobService.createJobRequest (C:\Users\awhite\code\reefguide-web-api\src\api\services\jobs.ts:286:16)
    at C:\Users\awhite\code\reefguide-web-api\src\api\jobs\routes.ts:133:58
    at newFn (C:\Users\awhite\code\reefguide-web-api\node_modules\express-async-errors\index.js:16:20)
    at Layer.handle [as handle_request] (C:\Users\awhite\code\reefguide-web-api\node_modules\express\lib\router\layer.js:95:5)
    at next (C:\Users\awhite\code\reefguide-web-api\node_modules\express\lib\router\route.js:149:13)
    at complete (C:\Users\awhite\code\reefguide-web-api\node_modules\passport\lib\middleware\authenticate.js:280:13)
    at C:\Users\awhite\code\reefguide-web-api\node_modules\passport\lib\middleware\authenticate.js:287:15
POST /api/jobs 400 24.569 ms - 75
```
